### PR TITLE
Update shortname to ui-security

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3,7 +3,7 @@ Title: User Interface Security and the Visibility API
 Status: WD
 Group: WebAppSec
 ED: https://w3c.github.io/webappsec-uisecurity/
-Shortname: UI Security
+Shortname: ui-security
 Level: 1
 Editor: Brad Hill, Facebook, hillbrad@fb.com
 !Author: Dan Kaminsky, White Ops


### PR DESCRIPTION
I don't know the status of this spec, but a change to the metadata shortname was requested in https://github.com/w3c/webappsec/issues/553.